### PR TITLE
Fix unused var warnings with placeholder

### DIFF
--- a/src/kye_script.cpp
+++ b/src/kye_script.cpp
@@ -302,120 +302,116 @@ void LoadKyeWall(char t, unsigned  char i, unsigned char j)
 
 void LoadXyeWall_R(unsigned char i, unsigned  char j)
 {
-    wall* wl=new wall(game::Square(i,j),4);
+    auto _ = new wall(game::Square(i,j),4);
 }
 
 void LoadKyeTimer(unsigned  char x, unsigned char y,unsigned char tm)
 {
-    number* t=new number(game::Square(x,y),B_YELLOW,tm,false);
+    auto _ = new number(game::Square(x,y),B_YELLOW,tm,false);
 }
 
 void LoadKyeEarth(unsigned  char x, unsigned char y)
 {
-    earth* e=new earth(game::Square(x,y));
+    auto _ = new earth(game::Square(x,y));
 }
 
 void LoadKyeGem(unsigned char x,unsigned char y)
 {
-    gem* g=new gem(game::Square(x,y),B_BLUE);
+    auto _ = new gem(game::Square(x,y),B_BLUE);
 }
 
 void LoadXyeEmerald(unsigned char x,unsigned char y)
 {
-    gem* g=new gem(game::Square(x,y),B_GREEN);
+    auto _ = new gem(game::Square(x,y),B_GREEN);
 }
 
 void LoadXyeGemBlock(unsigned char x,unsigned char y)
 {
-    gemblock* g=new gemblock(game::Square(x,y),B_GREEN);
+    auto _ = new gemblock(game::Square(x,y),B_GREEN);
 }
 
 void LoadXyeBlockDoor(unsigned char x,unsigned char y,bool trap)
 {
-    blockdoor* g=new blockdoor(game::Square(x,y),trap,true,B_YELLOW);
+    auto _ = new blockdoor(game::Square(x,y),trap,true,B_YELLOW);
 }
 
 
 void LoadXyeMarked(unsigned char x,unsigned char y)
 {
-    marked* g=new marked(game::Square(x,y),B_YELLOW);
+    auto _ = new marked(game::Square(x,y),B_YELLOW);
 }
 
 
 void LoadKyeBlock(unsigned  char x, unsigned char y,bool round, bool fromxye)
 {
-    block* b=new block(game::Square(x,y), /*(fromxye?B_YELLOW: B_GREEN)*/ B_YELLOW,round);
-
-
-
+    auto _ = new block(game::Square(x,y), /*(fromxye?B_YELLOW: B_GREEN)*/ B_YELLOW,round);
 }
 
 void LoadKyeBeast(unsigned char x, unsigned char y, btype B)
 {
-    beast* b=new beast(game::Square(x,y),B,D_UP);
+    auto _ = new beast(game::Square(x,y),B,D_UP);
 }
 
 void LoadKyeSticky(unsigned char x, unsigned char y, bool horz)
 {
-    magnetic* m=new magnetic(game::Square(x,y),T_MAGNET,horz);
+    auto _ = new magnetic(game::Square(x,y),T_MAGNET,horz);
 }
 
 void LoadSKyeSticky(unsigned char x, unsigned char y, bool horz)
 {
-    magnetic* m=new magnetic(game::Square(x,y),T_STICKY,horz);
+    auto _ = new magnetic(game::Square(x,y),T_STICKY,horz);
 }
 
 void LoadXyeAntiMagnet(unsigned char x, unsigned char y, bool horz)
 {
-    magnetic* m=new magnetic(game::Square(x,y),T_ANTIMAGNET,horz);
+    auto _ = new magnetic(game::Square(x,y),T_ANTIMAGNET,horz);
 }
 
 void LoadSKyeBomb(unsigned char x, unsigned char y)
 {
-    surprise* m=new surprise(game::Square(x,y),B_RED,false);
+    auto _ = new surprise(game::Square(x,y),B_RED,false);
 }
 
 void LoadSKyePit(unsigned char x, unsigned char y)
 {
-    pit* m=new pit(game::Square(x,y));
+    auto _ = new pit(game::Square(x,y));
 }
 
 void LoadKyeBlacky(unsigned char x, unsigned char y)
 {
-    dangerous* b=new dangerous(game::Square(x,y),OT_BLACKHOLE);
+    auto _ = new dangerous(game::Square(x,y),OT_BLACKHOLE);
 }
 
 void LoadXyeMine(unsigned char x, unsigned char y)
 {
-    dangerous* b=new dangerous(game::Square(x,y),OT_MINE);
+    auto _ = new dangerous(game::Square(x,y),OT_MINE);
 }
 
 
 void LoadKyeArrow(unsigned char x, unsigned char y, bool round, edir d)
 {
-    arrow *a=new arrow(game::Square(x,y),B_YELLOW,d,round);
+    auto _ = new arrow(game::Square(x,y),B_YELLOW,d,round);
 }
 
 void LoadKye3Teleport(unsigned char x, unsigned char y, edir d)
 {
-    teleport *a=new teleport(game::Square(x,y),d);
+    auto _ = new teleport(game::Square(x,y),d);
 }
 
 
 void LoadKyeBouncer(unsigned char x, unsigned char y, edir d)
 {
-    impacter *i=new impacter(game::Square(x,y),B_YELLOW,d);
+    auto _ = new impacter(game::Square(x,y),B_YELLOW,d);
 }
 
 void LoadKyeClockerAclocker(unsigned char x, unsigned char y,bool clockwise)
 {
-    turner *t=new turner(game::Square(x,y),B_YELLOW,clockwise,false);
+    auto _ = new turner(game::Square(x,y),B_YELLOW,clockwise,false);
 }
 
 void LoadKyeAuto(unsigned char x, unsigned char y,bool round)
 {
-    autoarrow* bc=new autoarrow(game::SquareN(x,y),B_YELLOW,autoarrow::GetDefaultEdirByColumn(x),round);
-
+    auto _ = new autoarrow(game::SquareN(x,y),B_YELLOW,autoarrow::GetDefaultEdirByColumn(x),round);
 }
 
 void LoadKyeOneWay(unsigned char x, unsigned char y,edir dr)
@@ -429,34 +425,32 @@ void LoadKyeOneWay(unsigned char x, unsigned char y,edir dr)
         default: u=true;
    }
 
-   tdoor* td= new tdoor(game::SquareN(x,y), (l || r)? td_HORZ:td_VERT  ,u,r,d,l);
-
+   auto _ = new tdoor(game::SquareN(x,y), (l || r)? td_HORZ:td_VERT  ,u,r,d,l);
 }
 
 void LoadXyeDotBlock(unsigned char x, unsigned char y,bool round)
 {
-    lowdensity* l=new lowdensity(game::SquareN(x,y),B_YELLOW,round);
+    auto _ = new lowdensity(game::SquareN(x,y),B_YELLOW,round);
 }
 
 void LoadXyeSurprise(unsigned char x, unsigned char y,bool round)
 {
-    surprise* l=new surprise(game::SquareN(x,y),B_BLUE,round);
+    auto _ = new surprise(game::SquareN(x,y),B_BLUE,round);
 }
 
 void LoadXyeToggle(unsigned char x, unsigned char y,bool plus)
 {
-    toggle* l=new toggle(game::SquareN(x,y),B_YELLOW,false,! plus);
+    auto _ = new toggle(game::SquareN(x,y),B_YELLOW,false,! plus);
 }
 
 void LoadXyeBot(unsigned char x, unsigned char y)
 {
-    roboxye* l=new roboxye(game::SquareN(x,y));
+    auto _ = new roboxye(game::SquareN(x,y));
 }
 
 /** Class KyeLevel start **/
 void KyeLevel::SetGameCaption()
 {
-    int L=name.length();
     string title = "Xye - "+name;
     LevelPack::CurrentLevelTitle=title.c_str();
     SDL_WM_SetCaption(title.c_str(),0);

--- a/src/xsb_level.cpp
+++ b/src/xsb_level.cpp
@@ -155,8 +155,8 @@ int SLC_CountValidLevels(TiXmlElement* levels)
             n++;
         el=el->NextSiblingElement("Level");
     }
-    
-    
+
+
     return n;
 }
 
@@ -164,7 +164,7 @@ string GetSokobanLevelName(const char* filename, int ln)
 {
     string name = GetFileNameNoExtension(filename);
     int len = name.length();
-    
+
     char buf[len+10];
     sprintf(buf, "%s %d", name.c_str(), ln);
     return string(buf);
@@ -183,9 +183,9 @@ void XsbLevelPack::LoadSLC(const char* filename, unsigned int ln)
         {
             el=pack->FirstChildElement("LevelCollection");
             if(el == NULL) {LevelPack::Error("Unable to find a <LevelCollection> tag.");return;}
-            
+
             tn = SLC_CountValidLevels(el);
-            
+
             int temlevel =0 ;
             for ( el= el->FirstChildElement("Level"); el != NULL; el = el->NextSiblingElement("Level") )
             {
@@ -200,7 +200,7 @@ void XsbLevelPack::LoadSLC(const char* filename, unsigned int ln)
                     std::swap(w,h);
                 }
                 if((w<0) || (h<0) || (w>XYE_HORZ) || (h>XYE_VERT) ) continue;
-                
+
                 XsbLevel* cur;
                 if( First == NULL )
                 {
@@ -220,28 +220,28 @@ void XsbLevelPack::LoadSLC(const char* filename, unsigned int ln)
                 for(int i=0; i<XYE_HORZ; i++)
                     for(int j=0; j<XYE_VERT; j++)
                        cur->data[i][j]='#';
-                       
+
                 cur->name = el->Attribute("Id");
                 if(cur->name=="")
                     cur->name = GetSokobanLevelName( filename, temlevel+1);
 
                 for (line = el->FirstChildElement("L"); line != NULL; line = line->NextSiblingElement("L") )
                 {
-                    const char* gt =line->GetText(); 
+                    const char* gt =line->GetText();
                     string row = ( (gt!=NULL) ? gt : "");
-                    
-                    
+
+
                     for(int i=0; i<row.length(); i++)
                         if(swapped)
                             cur->data[linenum][i]= row[i];
                         else
                             cur->data[i][linenum]= row[i];
-                    
+
                     linenum ++;
                 }
                 cur->levelnum = temlevel+1;
                 temlevel++;
-                
+
             }
 
         }
@@ -278,7 +278,7 @@ const char* XsbLevelPack::ReadDataSLC(const char* path,unsigned int &n, string&a
             if( (el != NULL) && (el->GetText()!=NULL) ) url = el->GetText();
             el=pack->FirstChildElement("LevelCollection");
             if(el == NULL) return "Unable to find a <LevelCollection> tag.";
-            
+
             n = SLC_CountValidLevels(el);
             author = el->Attribute("Copyright");
 
@@ -318,10 +318,10 @@ const char* XsbLevelPack::ReadData(const char* path,unsigned int &n, string&auth
 
             title = "Microban";
             return NULL;
-            
+
         }
     }
-    
+
     n=0;
     std::ifstream fl ;
     fl.open(path,std::ios::in | std::ios::binary);
@@ -334,7 +334,7 @@ const char* XsbLevelPack::ReadData(const char* path,unsigned int &n, string&auth
         return ("The file is empty");
     }
     loadFileToLines(fl);
-    
+
     std::string line;
     unsigned int L;
 
@@ -344,7 +344,7 @@ const char* XsbLevelPack::ReadData(const char* path,unsigned int &n, string&auth
         do {
             line = fileLine[lpos++];
         } while (! IsValidXsbLine(line)  && (lpos < fileLineN) );
-        
+
         if (lpos >= fileLineN) break;
 
         cw=0;
@@ -371,7 +371,7 @@ const char* XsbLevelPack::ReadData(const char* path,unsigned int &n, string&auth
         }
     }
     fl.close();
-    
+
     if (n==0) {
         return "Could not find compatible xsb levels.";
     }
@@ -407,16 +407,16 @@ void XsbLevelPack::Load(const char* filename, unsigned int ln)
     {
         return LoadSLC(filename, ln);
     }
-    
+
     std::string line;
     std::ifstream fl ;
     fl.open(filename,std::ios::in | std::ios::binary);
     if (! fl.is_open()) return LevelPack::Error("Unable to load level file (.Xsb) (stream error)");
     if (fl.eof()) return LevelPack::Error("Level File is empty");
-    
+
     loadFileToLines(fl);
-    
-    
+
+
     std::string buf;
     unsigned char ch,cw,i,j;
     unsigned int k,L;
@@ -424,7 +424,7 @@ void XsbLevelPack::Load(const char* filename, unsigned int ln)
     char c;
     tn=0;
     XsbLevel* current;
-    
+
     int lpos = 0;
     while (lpos < fileLineN) {
         //Non-necessary things:
@@ -602,7 +602,7 @@ bool XsbLevelPack::HasLast()
 
 void LoadXsbWall(unsigned  char i, unsigned char j,bool dark=false)
 {
-    wall* wl=new wall(game::Square(i,j));
+    auto wl = new wall(game::Square(i, j));
     if (dark)
     wl->ChangeColor(0,0,0);
 
@@ -610,12 +610,12 @@ void LoadXsbWall(unsigned  char i, unsigned char j,bool dark=false)
 
 void LoadXsbMarked(unsigned char x,unsigned char y,blockcolor bc)
 {
-    marked* g=new marked(game::Square(x,y),bc);
+    auto _ = new marked(game::Square(x, y), bc);
 }
 
 void LoadXsbBlock(unsigned  char x, unsigned char y,blockcolor bc)
 {
-    block* b=new block(game::Square(x,y),bc,false);
+    auto _ = new block(game::Square(x, y), bc, false);
 }
 
 
@@ -691,7 +691,7 @@ bool EnsurePath(unsigned char x,unsigned char y,int*mem,bool nowall,blockcolor b
             }
             wallrep=true;
             object->Kill();
-            blockdoor* g=new blockdoor(sq,false,true,bc);
+            auto _ = new blockdoor(sq, false, true, bc);
 
         }
     }
@@ -775,7 +775,7 @@ bool EnsurePath(unsigned char x,unsigned char y,int*mem,bool nowall,blockcolor b
 
     if (wallrep)
     {
-        wall* wl=new wall(game::Square(x,y),0);
+        auto _ = new wall(game::Square(x, y), 0);
     }
 
 return false;
@@ -799,7 +799,7 @@ bool FromXyeDFS(int* mem, unsigned char x, unsigned char y)
                 FromXyeDFS(mem,nx,ny);
             }
         }
-        
+
     }
     return ( (res==2) ? true: false);
 }
@@ -819,8 +819,8 @@ bool FindAGoodWall(int i, int j,bool rec=true)
             object->Kill();
             XsbLevel::tx=(i<0)?XYE_HORZ-1:(i>=XYE_HORZ)?0:i;
             XsbLevel::ty=(j<0)?XYE_VERT-1:(j>=XYE_VERT)?0:j;
-            blockdoor *bd= new blockdoor(sq,false,true,XsbLevel::bc);
-            gem* gm=new gem(sq,XsbLevel::bc);
+            auto _ = new blockdoor(sq, false, true, XsbLevel::bc);
+            auto __ = new gem(sq, XsbLevel::bc);
             return true;
         }
     }
@@ -932,7 +932,7 @@ $ - box
                 obj* object = sq->object;
                 if(object==NULL)
                 {
-                    wall* wl = new wall(sq);
+                    auto _ = new wall(sq);
                 }
             }
     delete[] mem;
@@ -968,7 +968,7 @@ $ - box
 
             square * sq = game::Square(i,j);
             obj* object = sq->object;
-            
+
         }
 
 

--- a/src/xye.cpp
+++ b/src/xye.cpp
@@ -4712,7 +4712,7 @@ void number::Draw(unsigned int x, unsigned int y)
 void number::explode()
 {
     deathqueue::add(x,y,KT_FIRE);
-    explosion *ex = new explosion(game::SquareN(x,y),1);
+    auto _ = new explosion(game::SquareN(x, y), 1);
 }
 
 bool number::trypush(edir dir,obj* pusher) {
@@ -5935,10 +5935,7 @@ void surprise::FinalExplode()
         for (j=-1;j<=1;j++)
             game::SmallBoom(game::SquareN(x+i,y+j), false, i,-j );
 
-    explosion* ex=new explosion(game::Square(x,y));;
-
-
-
+    auto _ = new explosion(game::Square(x, y));
 }
 
 /**End Class Surprise**/
@@ -6399,7 +6396,7 @@ inline bool dangerous::HasRoundCorner(roundcorner rnc) { return false; }
 inline void dangerous::Eat() {
     if (mine || fire)
     {
-        explosion* ex=new explosion(game::SquareN(x,y),1);
+        auto _ = new explosion(game::SquareN(x, y), 1);
         Kill();
     }
     else

--- a/src/xye_script.cpp
+++ b/src/xye_script.cpp
@@ -680,8 +680,7 @@ void Load_Gem(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el,B_BLUE);
 
-    gem* gm=new gem(game::SquareN(LastX,LastY),c);
-
+    auto _ = new gem(game::SquareN(LastX,LastY),c);
 }
 
 /* Load Star*/
@@ -690,7 +689,7 @@ void Load_Star(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
 
-    star* gm=new star(game::SquareN(LastX,LastY) );
+    auto _ = new star(game::SquareN(LastX,LastY) );
 
 }
 
@@ -708,7 +707,7 @@ void Load_Number(TiXmlElement* el)
         blockcolor c=GetElementBlockColor(el,B_YELLOW);
         el->QueryIntAttribute("round",&round);
 
-    number* gm=new number(game::SquareN(LastX,LastY),c,cv,round);
+    auto _ = new number(game::SquareN(LastX,LastY),c,cv,round);
 }
 
 
@@ -720,7 +719,7 @@ void Load_Robot(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
 
-    roboxye* rb=new roboxye(game::SquareN(LastX,LastY));
+    auto _ = new roboxye(game::SquareN(LastX,LastY));
 }
 
 
@@ -736,7 +735,7 @@ void Load_Blackhole(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
 
 
-    dangerous* dn=new dangerous(game::SquareN(LastX,LastY),OT_BLACKHOLE);
+    auto _ = new dangerous(game::SquareN(LastX,LastY),OT_BLACKHOLE);
 
 }
 
@@ -747,7 +746,7 @@ void Load_Mine(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
 
 
-    dangerous* dn=new dangerous(game::SquareN(LastX,LastY),OT_MINE);
+    auto _ = new dangerous(game::SquareN(LastX,LastY),OT_MINE);
 
 }
 
@@ -763,7 +762,7 @@ void Load_Block(TiXmlElement* el)
         el->QueryIntAttribute("nocolor",&colorless);
         el->QueryIntAttribute("round",&round);
 
-    block* dn=new block(game::SquareN(LastX,LastY),c, round);
+    auto dn = new block(game::SquareN(LastX,LastY),c, round);
     if (colorless) dn->colorless=true;
 
 }
@@ -791,12 +790,12 @@ void Load_LargeBlock(TiXmlElement* el)
     }
     if( !(up|down|left|right))
     {  //don't bother
-       block* dn=new block(game::SquareN(LastX,LastY),c, false);
+       auto dn = new block(game::SquareN(LastX,LastY),c, false);
        if (colorless) dn->colorless=true;
     }
     else
     {
-        largeblock* bc=new largeblock(game::SquareN(LastX,LastY),c, up,right,down,left);
+        auto bc = new largeblock(game::SquareN(LastX,LastY),c, up,right,down,left);
         if (colorless) bc->colorless=true;
     }
 
@@ -811,7 +810,7 @@ void Load_WindowBlock(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
 
-    windowblock* bc=new windowblock(game::SquareN(LastX,LastY),c);
+    auto _ = new windowblock(game::SquareN(LastX,LastY),c);
 
 
 }
@@ -824,7 +823,7 @@ void Load_RFood(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
 
-    rfood* rf=new rfood(game::SquareN(LastX,LastY));
+    auto _ = new rfood(game::SquareN(LastX,LastY));
 
 
 }
@@ -840,7 +839,7 @@ void Load_Rattler(TiXmlElement* el)
         el->QueryIntAttribute("grow",&grow);
         edir d=GetElementDir(el, D_DOWN );
 
-    rattler* rt=new rattler(game::SquareN(LastX,LastY),d,grow);
+    auto rt = new rattler(game::SquareN(LastX, LastY), d, grow);
     TiXmlElement* nd=el->FirstChildElement("body");
     while (nd)
     {
@@ -859,7 +858,7 @@ void Load_Lock(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
-    lock* bc=new lock(game::SquareN(LastX,LastY),c);
+    auto _ = new lock(game::SquareN(LastX,LastY),c);
 }
 
 /* Load Key*/
@@ -868,7 +867,7 @@ void Load_Key(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
-    key* bc=new key(game::SquareN(LastX,LastY),c);
+    auto _ = new key(game::SquareN(LastX,LastY),c);
 }
 
 
@@ -884,7 +883,7 @@ void Load_LowDensity(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
         el->QueryIntAttribute("round",&round);
-    lowdensity* bc=new lowdensity(game::SquareN(LastX,LastY),c,round);
+    auto bc = new lowdensity(game::SquareN(LastX,LastY),c,round);
     if (el->Attribute("active") ) bc->Activate(GetElementDir(el,D_DOWN,"active"));
 }
 
@@ -899,7 +898,7 @@ void Load_Surprise(TiXmlElement* el)
         blockcolor c=GetElementBlockColor(el);
         el->QueryIntAttribute("round",&round);
 
-    surprise* bc=new surprise(game::SquareN(LastX,LastY),c,round);
+    auto _ = new surprise(game::SquareN(LastX,LastY),c,round);
 
 
 }
@@ -916,7 +915,7 @@ void Load_Turner(TiXmlElement* el,unsigned int aclock)
         el->QueryIntAttribute("nocolor",&colorless);
         el->QueryIntAttribute("round",&round);
 
-    turner* bc=new turner(game::SquareN(LastX,LastY),c,!(aclock),round);
+    auto bc = new turner(game::SquareN(LastX,LastY),c,!(aclock),round);
     if (colorless) bc->colorless=true;
 
 
@@ -931,7 +930,7 @@ void Load_GemBlock(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
 
-    gemblock* bc=new gemblock(game::SquareN(LastX,LastY),c);
+    auto _ = new gemblock(game::SquareN(LastX,LastY),c);
 
 
 }
@@ -945,7 +944,7 @@ void Load_WildCard(TiXmlElement* el)
         int r=0;
         el->QueryIntAttribute("round",&r);
 
-    wildcard* wd=new wildcard(game::SquareN(LastX,LastY),(bool)(r) );
+    auto _ = new wildcard(game::SquareN(LastX,LastY),(bool)(r) );
 
 
 }
@@ -959,7 +958,7 @@ void Load_MetalBlock(TiXmlElement* el)
         int r=0;
         el->QueryIntAttribute("round",&r);
 
-    metalblock* mb=new metalblock(game::SquareN(LastX,LastY),(bool)(r) );
+    auto _ = new metalblock(game::SquareN(LastX,LastY),(bool)(r) );
 
 
 }
@@ -975,7 +974,7 @@ void Load_Earth(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         el->QueryIntAttribute("round",&r);
 
-    earth* et=new earth(game::SquareN(LastX,LastY));
+    auto et = new earth(game::SquareN(LastX,LastY));
     if (! options::LevelColorsDisabled()) {
         el->QueryIntAttribute("color",&c);
         if (c) {
@@ -1002,7 +1001,7 @@ void Load_Auto(TiXmlElement* el)
 
         el->QueryIntAttribute("round",&round);
 
-    autoarrow* bc=new autoarrow(game::SquareN(LastX,LastY),c,d,round);
+    auto _ = new autoarrow(game::SquareN(LastX,LastY),c,d,round);
 
 
 
@@ -1052,7 +1051,7 @@ void Load_Factory(TiXmlElement* el)
              rs=OT_BLOCK;
         }
 
-    factory* f=new factory(game::SquareN(LastX,LastY),rs,c,d,sd,round,colorless,(btype)(ib%BEASTN));
+    auto f = new factory(game::SquareN(LastX,LastY),rs,c,d,sd,round,colorless,(btype)(ib%BEASTN));
     f->limit=limit;
 
 
@@ -1072,7 +1071,7 @@ void Load_Filler(TiXmlElement* el)
 
         el->QueryIntAttribute("round",&round);
 
-    filler* bc=new filler(game::SquareN(LastX,LastY),c,d,round);
+    auto _ = new filler(game::SquareN(LastX,LastY),c,d,round);
 
 
 
@@ -1089,7 +1088,7 @@ void Load_Sniper(TiXmlElement* el)
 
         el->QueryIntAttribute("round",&round);
 
-    sniper* bc=new sniper(game::SquareN(LastX,LastY),c,round);
+    auto _ = new sniper(game::SquareN(LastX,LastY),c,round);
 
 
 
@@ -1108,7 +1107,7 @@ void Load_Arrow(TiXmlElement* el)
 
         el->QueryIntAttribute("round",&round);
 
-    arrow* bc=new arrow(game::SquareN(LastX,LastY),c,d,round);
+    auto _ = new arrow(game::SquareN(LastX,LastY),c,d,round);
 
 
 
@@ -1128,7 +1127,7 @@ void Load_ScrollBlock(TiXmlElement* el)
         el->QueryIntAttribute("nocolor",&nocolor);
 
 
-    scrollblock* bc=new scrollblock(game::SquareN(LastX,LastY),c,round,d);
+    auto bc = new scrollblock(game::SquareN(LastX,LastY),c,round,d);
     bc->colorless=nocolor;
 
 
@@ -1145,11 +1144,7 @@ void Load_Teleport(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         edir d=GetElementDir(el, D_DOWN );
 
-
-    teleport* tp=new teleport(game::SquareN(LastX,LastY),d);
-
-
-
+    auto _ = new teleport(game::SquareN(LastX,LastY),d);
 }
 
 
@@ -1172,7 +1167,7 @@ void Load_Toggle(TiXmlElement* el)
 
         el->QueryIntAttribute("round",&round);
 
-    toggle* bc=new toggle(game::SquareN(LastX,LastY),c,round, ! off);
+    auto _ = new toggle(game::SquareN(LastX,LastY),c,round, ! off);
 
 
 
@@ -1189,7 +1184,7 @@ void Load_Pusher(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
         edir d=GetElementDir(el, D_DOWN );
-    impacter* bc=new impacter(game::SquareN(LastX,LastY), c,d);
+    auto _ = new impacter(game::SquareN(LastX,LastY), c,d);
 
 
 
@@ -1206,7 +1201,7 @@ void Load_Beast(TiXmlElement* el)
         el->QueryIntAttribute("kind",&ib);
 
         edir d=GetElementDir(el, D_DOWN );
-    beast* bc=new beast(game::SquareN(LastX,LastY), btype(ib),d);
+    auto _ = new beast(game::SquareN(LastX,LastY), btype(ib),d);
 
 
 
@@ -1228,7 +1223,7 @@ void Load_Magnet(TiXmlElement* el)
 
 
 
-    magnetic* mg=new magnetic(game::SquareN(LastX,LastY), (mgtype)(kind), horz  );
+    auto _ = new magnetic(game::SquareN(LastX,LastY), (mgtype)(kind), horz  );
 
 
 
@@ -1239,14 +1234,14 @@ void Load_Magnet(TiXmlElement* el)
 /* Load BlockDoor */
 void Load_BlockDoor(TiXmlElement* el, unsigned int AsTrap)
 {
-    int open=0,round=0;
+    int open=0;
 
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
         el->QueryIntAttribute("open",&open);
 
-    blockdoor* bc=new blockdoor(game::SquareN(LastX,LastY),(AsTrap!=0), (! open),c);
+    auto _ = new blockdoor(game::SquareN(LastX,LastY),(AsTrap!=0), (! open),c);
 }
 
 /* Load Marked Area */
@@ -1256,7 +1251,7 @@ void Load_Marked(TiXmlElement* el)
         el->QueryIntAttribute("y",&LastY);
         blockcolor c=GetElementBlockColor(el);
 
-    marked* bc=new marked(game::SquareN(LastX,LastY), c);
+    auto _ = new marked(game::SquareN(LastX,LastY), c);
 }
 
 /* Load Fire Pad*/
@@ -1265,7 +1260,7 @@ void Load_FirePad(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
 
-    firepad* fp=new firepad(game::SquareN(LastX,LastY));
+    auto _ = new firepad(game::SquareN(LastX,LastY));
 }
 
 /* Load Pit*/
@@ -1274,7 +1269,7 @@ void Load_Pit(TiXmlElement* el)
         el->QueryIntAttribute("x",&LastX);
         el->QueryIntAttribute("y",&LastY);
 
-    pit* fp=new pit(game::SquareN(LastX,LastY));
+    auto _ = new pit(game::SquareN(LastX,LastY));
 }
 
 
@@ -1287,7 +1282,7 @@ void Load_Hint(TiXmlElement* el, bool warn)
         /*el->QueryIntAttribute("color",&c1);*/
     const char* tx = el->GetText ();
     string text = ( (tx!=NULL) ? tx : "") ;
-    hint* hn=new hint(game::SquareN(LastX,LastY), text, warn);
+    auto hn = new hint(game::SquareN(LastX,LastY), text, warn);
     /*if (c1!=0)
     {
         el->QueryIntAttribute("markcolor",&c2);
@@ -1330,7 +1325,7 @@ void Load_Portal(TiXmlElement* el)
         palette::GetColor(c,R,G,B);
     }
 
-    portal* pt= new portal(game::SquareN(LastX,LastY),R,G,B,tx,ty);
+    auto _ = new portal(game::SquareN(LastX,LastY),R,G,B,tx,ty);
 }
 
 /* Load TrickDoor */
@@ -1391,7 +1386,7 @@ void Load_TrickDoor(TiXmlElement* el, int opt)
 
    }
 
-   tdoor* td= new tdoor(game::SquareN(LastX,LastY),tt,u,r,d,l);
+   auto td = new tdoor(game::SquareN(LastX, LastY), tt, u, r, d, l);
    Uint8 red,green,blue;
 
 
@@ -1789,7 +1784,7 @@ void LevelPack::Default(const char* msg)
         for (int j=0;j<20; j++)
         {
             if(err[i][j]=='#') {
-                block* b =  new block(game::Square(5+j,12-i) , B_RED, false);
+                auto _ = new block(game::Square(5+j,12-i) , B_RED, false);
             }
         }
 


### PR DESCRIPTION
The code base contains several instances of lines like this:

```c++
earth* e = new earth(game::Square(x, y));
```

where the variable is never used afterwards. The compiler warns about this.
There is a proposal for future C++ versions for using the single underscore `_` as a placeholder for unused variables. Compilers already avoid warnings for unused variables with such a name. This PR renames such unused variables.

```c++
auto _ = new earth(game::Square(x, y));
```

Notice that the keyword `auto` is used to avoid duplication as the type name is already present in the line.

NOTE: A separate issue is the allocation on the heap of an object whose pointer is immediately thrown away. This might be an indication of a potential memory leak, unless each constructor has a special mechanism to "subscribe" its reference in some way. I haven't looked into this for the moment.